### PR TITLE
Fix failing unittest due to double imprecision.

### DIFF
--- a/std/csv.d
+++ b/std/csv.d
@@ -510,6 +510,8 @@ auto csvReader(Contents = string,
 // Test structure conversion interface with unicode.
 @safe pure unittest
 {
+    import std.math : abs;
+
     wstring str = "\U00010143Hello,65,63.63\nWorld,123,3673.562"w;
     struct Layout
     {
@@ -533,7 +535,7 @@ auto csvReader(Contents = string,
     {
         assert(ans[count].name == record.name);
         assert(ans[count].value == record.value);
-        assert(ans[count].other == record.other);
+        assert(abs(ans[count].other - record.other) < 0.00001);
         count++;
     }
     assert(count == ans.length);
@@ -556,6 +558,8 @@ auto csvReader(Contents = string,
 // Test struct & header interface and same unicode
 unittest
 {
+    import std.math : abs;
+
     string str = "a,b,c\nHello,65,63.63\n➊➋➂❹,123,3673.562";
     struct Layout
     {
@@ -579,7 +583,7 @@ unittest
     {
         assert(ans[count].name == record.name);
         assert(ans[count].value == record.value);
-        assert(ans[count].other == record.other);
+        assert(abs(ans[count].other - record.other) < 0.00001);
         count++;
     }
     assert(count == ans.length);


### PR DESCRIPTION
Updated two test cases to compare doubles with  

    absolute(a-b) < precision